### PR TITLE
Added light-version option to build script

### DIFF
--- a/product-light.svg
+++ b/product-light.svg
@@ -1,0 +1,719 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="128"
+   height="128"
+   viewBox="0 0 128 128.00001"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="product.svg"
+   inkscape:export-filename="/home/spooky/g12314.png"
+   inkscape:export-xdpi="351.56"
+   inkscape:export-ydpi="351.56">
+  <defs
+     id="defs4">
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.3359878"
+       y="-0.16799387"
+       width="1.3360122"
+       x="-0.16800612"
+       id="filter8002"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur8004"
+         stdDeviation="1.1900434"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.444"
+       y="-0.222"
+       width="1.444"
+       x="-0.222"
+       id="filter7558"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7560"
+         stdDeviation="1.2025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.271572"
+       y="-0.13578603"
+       width="1.440506"
+       x="-0.22025298"
+       id="filter7590"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7592"
+         stdDeviation="1.1924025"
+         inkscape:collect="always" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour1"
+       id="linearGradient4727"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0283134,0,0,0.98361153,343.32301,796.71719)"
+       x1="17.871185"
+       y1="7.6685314"
+       x2="17.871185"
+       y2="17.89324" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0283134,0,0,0.98361153,343.32301,796.71719)"
+       x1="17.871185"
+       y1="7.6685314"
+       x2="17.871185"
+       y2="17.89324"
+       id="linearGradient-colour1">
+      <stop
+         stop-color="#FBB114"
+         offset="0%"
+         id="stop7" />
+      <stop
+         stop-color="#FF9508"
+         offset="100%"
+         id="stop9" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour2"
+       id="linearGradient4729"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94465199,0,0,1.0707233,343.32301,796.71719)"
+       x1="23.954397"
+       y1="8.6098804"
+       x2="23.954397"
+       y2="19.256279" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94465199,0,0,1.0707233,343.32301,796.71719)"
+       x1="23.954397"
+       y1="8.6098804"
+       x2="23.954397"
+       y2="19.256279"
+       id="linearGradient-colour2">
+      <stop
+         stop-color="#FF645D"
+         offset="0%"
+         id="stop12" />
+      <stop
+         stop-color="#FF4332"
+         offset="100%"
+         id="stop14" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour3"
+       id="linearGradient4731"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1037078,0,0,0.91642091,343.32301,796.71719)"
+       x1="20.12693"
+       y1="19.205147"
+       x2="20.12693"
+       y2="29.033293" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1037078,0,0,0.91642091,343.32301,796.71719)"
+       x1="20.12693"
+       y1="19.205147"
+       x2="20.12693"
+       y2="29.033293"
+       id="linearGradient-colour3">
+      <stop
+         stop-color="#CA70E1"
+         offset="0%"
+         id="stop17" />
+      <stop
+         stop-color="#B452CB"
+         offset="100%"
+         id="stop19" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour4"
+       id="linearGradient4733"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0283134,0,0,0.98361158,343.32301,796.71719)"
+       x1="16.359619"
+       y1="17.89324"
+       x2="16.359619"
+       y2="28.117949" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.0283134,0,0,0.98361158,343.32301,796.71719)"
+       x1="16.359619"
+       y1="17.89324"
+       x2="16.359619"
+       y2="28.117949"
+       id="linearGradient-colour4">
+      <stop
+         stop-color="#14ADF6"
+         offset="0%"
+         id="stop22" />
+      <stop
+         stop-color="#1191F4"
+         offset="100%"
+         id="stop24" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour5"
+       id="linearGradient4735"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94465199,0,0,1.0707233,343.32301,796.71719)"
+       x1="13.307998"
+       y1="13.618688"
+       x2="13.307998"
+       y2="24.265087" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(0.94465199,0,0,1.0707233,343.32301,796.71719)"
+       x1="13.307998"
+       y1="13.618688"
+       x2="13.307998"
+       y2="24.265087"
+       id="linearGradient-colour5">
+      <stop
+         stop-color="#52CF30"
+         offset="0%"
+         id="stop27" />
+      <stop
+         stop-color="#3BBD1C"
+         offset="100%"
+         id="stop29" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient-colour6"
+       id="linearGradient4737"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1037078,0,0,0.91642092,343.32301,796.71719)"
+       x1="11.765563"
+       y1="9.3769989"
+       x2="11.765563"
+       y2="19.205147" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.1037078,0,0,0.91642092,343.32301,796.71719)"
+       x1="11.765563"
+       y1="9.3769989"
+       x2="11.765563"
+       y2="19.205147"
+       id="linearGradient-colour6">
+      <stop
+         stop-color="#FFD305"
+         offset="0%"
+         id="stop32" />
+      <stop
+         stop-color="#FDCF01"
+         offset="100%"
+         id="stop34" />
+    </linearGradient>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.2715721"
+       y="-0.13578606"
+       width="1.4405057"
+       x="-0.22025287"
+       id="filter7618"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7620"
+         stdDeviation="1.1924028"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.271572"
+       y="-0.13578603"
+       width="1.440506"
+       x="-0.22025298"
+       id="filter7382"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7384"
+         stdDeviation="1.1924025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.444"
+       y="-0.222"
+       width="1.444"
+       x="-0.222"
+       id="filter7410"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7412"
+         stdDeviation="1.2025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.2715721"
+       y="-0.13578606"
+       width="1.4405057"
+       x="-0.22025287"
+       id="filter7330"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7332"
+         stdDeviation="1.1924028"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.444"
+       y="-0.222"
+       width="1.444"
+       x="-0.222"
+       id="filter7358"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7360"
+         stdDeviation="1.2025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.271572"
+       y="-0.13578603"
+       width="1.440506"
+       x="-0.22025298"
+       id="filter7274"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7276"
+         stdDeviation="1.1924025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.444"
+       y="-0.222"
+       width="1.444"
+       x="-0.222"
+       id="filter7302"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7304"
+         stdDeviation="1.2025"
+         inkscape:collect="always" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       height="1.2680809"
+       y="-0.13404046"
+       width="1.2793511"
+       x="-0.13967554"
+       id="filter7818"
+       inkscape:collect="always">
+      <feGaussianBlur
+         id="feGaussianBlur7820"
+         stdDeviation="1.1885652"
+         inkscape:collect="always" />
+    </filter>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#dcdcdc"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8"
+     inkscape:cx="113.38236"
+     inkscape:cy="36.47243"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px" />
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-924.36222)">
+    <g
+       transform="translate(-259.88103,178.48725)"
+       style="display:inline"
+       id="g12622">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7558);enable-background:accumulate"
+         d="m 290.5,808.375 c -3.58985,0 -6.5,2.91015 -6.5,6.5 0,3.58985 2.91015,6.5 6.5,6.5 3.58985,0 6.5,-2.91015 6.5,-6.5 0,-3.58985 -2.91015,-6.5 -6.5,-6.5 z"
+         id="path7438"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7590);enable-background:accumulate"
+         d="m 273.8125,795.28125 c -0.46695,0.0551 -0.823,0.4979 -0.8125,1.09375 l 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 l 3.59375,0 2.6875,2.6875 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1,-0.5 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l 0,-3.59375 2.71875,-2.71875 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.3075,-0.3075 -0.62608,-0.40806 -0.90625,-0.375 z"
+         id="path7454"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="translate(109.79092,32.127067)"
+         id="g11425-5"
+         style="display:inline">
+        <path
+           sodipodi:nodetypes="ccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path11427-0"
+           d="m 163.20931,763.14731 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 0,0 3.88258,-1.25944 3.72633,-1.21534 l 2.55492,3.90284 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1.00846,-0.47958 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l -0.87488,-4.65633 3.58517,-1.67659 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.81999,-0.81999 -1.73555,-0.23461 -1.71875,0.71875 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           inkscape:connector-curvature="0"
+           id="path11429-9"
+           d="m 164.20931,779.13449 0,-16 11,11.5 -3.86642,1.95784 0.9122,5.09495 -1.04578,0.44721 -2.86742,-4.21534 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+      <g
+         transform="matrix(0.59090905,0,0,0.59090905,77.227388,332.57381)"
+         id="g4618-0"
+         style="display:inline">
+        <circle
+           r="10.999999"
+           cy="814.31714"
+           cx="360.92291"
+           id="circle4566-9"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4568-3"
+           d="m 367.00513,805.15019 c 0.33342,0.78907 0.51778,1.65647 0.51778,2.56694 0,3.64508 -2.95492,6.6 -6.6,6.6 1.82253,-3.15674 0.74096,-7.19323 -2.41577,-9.01576 -0.78918,-0.45563 -1.63334,-0.72977 -2.48415,-0.83534 1.47548,-0.73531 3.13939,-1.1489 4.89992,-1.1489 2.24884,0 4.34007,0.67484 6.08222,1.83306 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4570-6"
+           d="m 371.90192,815.0022 c -0.51649,0.68278 -1.17521,1.27572 -1.96325,1.7307 -3.15672,1.82254 -7.19323,0.74097 -9.01576,-2.41577 3.64508,0 6.6,-2.95492 6.6,-6.6 0,-0.91047 -0.18436,-1.77787 -0.51778,-2.56694 2.96417,1.97065 4.91778,5.34066 4.91778,9.16694 0,0.23008 -0.007,0.4585 -0.021,0.68507 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4572-0"
+           d="m 365.82282,824.16823 c -0.8508,-0.1056 -1.69496,-0.3797 -2.48415,-0.83534 -3.15672,-1.82253 -4.2383,-5.85902 -2.41576,-9.01576 1.82253,3.15674 5.85904,4.23831 9.01576,2.41577 0.78804,-0.45498 1.44676,-1.04792 1.96325,-1.7307 -0.24716,4.02231 -2.65592,7.46006 -6.0791,9.16603 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4574-6"
+           d="m 354.84069,823.48407 c -0.33342,-0.78907 -0.51778,-1.65647 -0.51778,-2.56694 0,-3.64508 2.95492,-6.6 6.6,-6.6 -1.82254,3.15674 -0.74096,7.19323 2.41576,9.01576 0.78919,0.45564 1.63335,0.72977 2.48415,0.83534 -1.47547,0.73531 -3.13938,1.1489 -4.89991,1.1489 -2.24884,0 -4.34007,-0.67484 -6.08222,-1.83306 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4576-2"
+           d="m 349.9439,813.63206 c 0.51649,-0.68278 1.1752,-1.27572 1.96324,-1.73069 3.15673,-1.82255 7.19323,-0.74098 9.01577,2.41576 -3.64508,0 -6.6,2.95492 -6.6,6.6 0,0.91047 0.18436,1.77787 0.51778,2.56694 -2.96417,-1.97065 -4.91778,-5.34066 -4.91778,-9.16694 0,-0.23008 0.007,-0.4585 0.021,-0.68507 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <path
+           id="path4578-6"
+           d="m 356.02299,804.46603 c 0.85081,0.1056 1.69497,0.37971 2.48415,0.83534 3.15673,1.82253 4.2383,5.85902 2.41577,9.01576 -1.82254,-3.15674 -5.85904,-4.23831 -9.01577,-2.41576 -0.78804,0.45497 -1.44675,1.04791 -1.96324,1.73069 0.24716,-4.02231 2.65591,-7.46005 6.07909,-9.16603 l 0,0 z"
+           inkscape:connector-curvature="0"
+           style="fill:#1a1a1a;fill-rule:evenodd;stroke:none;stroke-width:1" />
+        <circle
+           style="fill:#959595;fill-rule:evenodd;stroke:none;stroke-width:1"
+           id="background-1"
+           cx="360.923"
+           cy="814.3172"
+           r="10.057142" />
+        <path
+           style="fill:url(#linearGradient4727);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 366.48389,805.93599 c 0.30484,0.72142 0.4734,1.51448 0.4734,2.34692 0,3.33263 -2.70163,6.03428 -6.03428,6.03428 1.66632,-2.88616 0.67745,-6.57667 -2.2087,-8.243 -0.72154,-0.41657 -1.49334,-0.6672 -2.27123,-0.76373 1.34901,-0.67228 2.87031,-1.05042 4.47993,-1.05042 2.05608,0 3.96806,0.617 5.56088,1.67595 l 0,0 z"
+           id="orange-8" />
+        <path
+           style="fill:url(#linearGradient4729);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 370.96096,814.94354 c -0.47222,0.62426 -1.07448,1.16637 -1.79497,1.58235 -2.88615,1.66632 -6.57666,0.67745 -8.24298,-2.2087 3.33265,0 6.03428,-2.70165 6.03428,-6.03428 0,-0.83244 -0.16856,-1.6255 -0.4734,-2.34692 2.7101,1.80173 4.49626,4.88288 4.49626,8.3812 0,0.21035 -0.007,0.41919 -0.0191,0.62635 l 0,0 z"
+           id="red-7" />
+        <path
+           style="fill:url(#linearGradient4731);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 365.40292,823.32391 c -0.77787,-0.0965 -1.54968,-0.34716 -2.27121,-0.76374 -2.88616,-1.66632 -3.87503,-5.35683 -2.2087,-8.24298 1.66632,2.88615 5.35683,3.87502 8.24298,2.2087 0.72049,-0.41598 1.32275,-0.95809 1.79497,-1.58235 -0.22598,3.67754 -2.42826,6.82061 -5.55804,8.38037 l 0,0 z"
+           id="purple-9" />
+        <path
+           style="fill:url(#linearGradient4733);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 355.36212,822.69838 c -0.30484,-0.72142 -0.47339,-1.51448 -0.47339,-2.34691 0,-3.33264 2.70163,-6.03428 6.03428,-6.03428 -1.66633,2.88615 -0.67746,6.57666 2.2087,8.24298 0.72153,0.41658 1.49334,0.66721 2.27121,0.76374 -1.34899,0.67228 -2.87029,1.05042 -4.47991,1.05042 -2.05609,0 -3.96806,-0.617 -5.56089,-1.67595 l 0,0 z"
+           id="blue-2" />
+        <path
+           style="fill:url(#linearGradient4735);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 350.88506,813.69083 c 0.47222,-0.62426 1.07448,-1.16637 1.79496,-1.58235 2.88615,-1.66632 6.57666,-0.67745 8.24299,2.20871 -3.33265,0 -6.03428,2.70164 -6.03428,6.03428 0,0.83243 0.16855,1.62549 0.47339,2.34691 -2.7101,-1.80173 -4.49626,-4.88288 -4.49626,-8.38119 0,-0.21036 0.007,-0.4192 0.0191,-0.62636 l 0,0 z"
+           id="green-0" />
+        <path
+           style="fill:url(#linearGradient4737);fill-rule:evenodd;stroke:none;stroke-width:1"
+           inkscape:connector-curvature="0"
+           d="m 356.44308,805.31046 c 0.77789,0.0966 1.54969,0.34716 2.27123,0.76373 2.88615,1.66633 3.87502,5.35684 2.2087,8.243 -1.66633,-2.88616 -5.35684,-3.87503 -8.24299,-2.20871 -0.72048,0.41598 -1.32274,0.95809 -1.79496,1.58235 0.22597,-3.67754 2.42826,-6.82061 5.55802,-8.38037 l 0,0 z"
+           id="yellow-2" />
+      </g>
+    </g>
+    <g
+       style="display:inline"
+       id="g12736"
+       transform="translate(-184.2298,167.23191)">
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter8002);enable-background:accumulate"
+         d="m 282.8125,854.375 a 1.0001,1.0001 0 0 0 -0.625,1.5625 l 2,2.9375 c -1.26807,1.2117 -2.1875,2.72907 -2.1875,4.5 0,1.84209 0.98678,3.40219 2.34375,4.625 l -1.1875,1.84375 A 1.0001,1.0001 0 0 0 284,871.375 l 1,0 a 1.0001,1.0001 0 0 0 0.84375,-0.4375 l 0.90625,-1.375 c 1.13954,0.47399 2.38541,0.8125 3.75,0.8125 0.73807,0 1.4143,-0.13533 2.09375,-0.28125 l 0.5625,0.84375 A 1.0001,1.0001 0 0 0 294,871.375 l 4,0 a 1.0001,1.0001 0 0 0 0.8125,-1.5625 l -1.59375,-2.34375 C 298.25477,866.32319 299,864.95536 299,863.375 c 0,-2.01272 -1.16841,-3.71024 -2.75,-4.96875 l 1.59375,-2.5 A 1.0001,1.0001 0 0 0 297,854.375 l -1,0 a 1.0001,1.0001 0 0 0 -0.84375,0.4375 l -1.5,2.21875 C 292.65492,856.6961 291.63694,856.375 290.5,856.375 c -0.51747,0 -1.00566,0.0842 -1.5,0.15625 l -1.15625,-1.71875 A 1.0001,1.0001 0 0 0 287,854.375 l -4,0 a 1.0001,1.0001 0 0 0 -0.0937,0 1.0001,1.0001 0 0 0 -0.0937,0 z"
+         id="path4340-6-2-7" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="m 282.8125,853.375 a 1.0001,1.0001 0 0 0 -0.625,1.5625 l 2,2.9375 c -1.26807,1.2117 -2.1875,2.72907 -2.1875,4.5 0,1.84209 0.98678,3.40219 2.34375,4.625 l -1.1875,1.84375 A 1.0001,1.0001 0 0 0 284,870.375 l 1,0 a 1.0001,1.0001 0 0 0 0.84375,-0.4375 l 0.90625,-1.375 c 1.13954,0.47399 2.38541,0.8125 3.75,0.8125 0.73807,0 1.4143,-0.13533 2.09375,-0.28125 l 0.5625,0.84375 A 1.0001,1.0001 0 0 0 294,870.375 l 4,0 a 1.0001,1.0001 0 0 0 0.8125,-1.5625 l -1.59375,-2.34375 C 298.25477,865.32319 299,863.95536 299,862.375 c 0,-2.01272 -1.16841,-3.71024 -2.75,-4.96875 l 1.59375,-2.5 A 1.0001,1.0001 0 0 0 297,853.375 l -1,0 a 1.0001,1.0001 0 0 0 -0.84375,0.4375 l -1.5,2.21875 C 292.65492,855.6961 291.63694,855.375 290.5,855.375 c -0.51747,0 -1.00566,0.0842 -1.5,0.15625 l -1.15625,-1.71875 A 1.0001,1.0001 0 0 0 287,853.375 l -4,0 a 1.0001,1.0001 0 0 0 -0.0937,0 1.0001,1.0001 0 0 0 -0.0937,0 z"
+         id="path4340-6-2"
+         inkscape:connector-curvature="0" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         d="m 298,869.36218 -4,0 -4,-6 6,-9 1,0 -4.5,7 z"
+         id="path4340"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         d="m 283,854.36218 4,0 4,6 -6,9 -1,0 4.5,-7 z"
+         id="path4340-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         style="fill:#f67400;fill-opacity:1;stroke:none"
+         d="m 290,856.375 -0.0312,0.0312 c -0.20155,0.0111 -0.39693,0.039 -0.59375,0.0625 l 1.40625,2.09375 c 0.25051,-0.64351 0.90547,-1.01902 1.65625,-1 0.16549,0.004 0.3283,0.0523 0.5,0.0937 0.0208,0.005 0.0417,-0.006 0.0625,0 0.22742,0.0669 0.44237,0.1616 0.65625,0.25 l 0.5,-0.78125 c -1.08346,-0.4862 -2.32559,-0.75 -3.65625,-0.75 -0.1555,0 -0.3156,0.0238 -0.46875,0.0312 L 290,856.375 Z m 4.9375,1.1875 -0.46875,0.75 c 1.52098,0.90773 2.53125,2.38481 2.53125,4.0625 0,2.76142 -2.68629,5 -6,5 -3.31371,0 -6,-2.23858 -6,-5 0,-1.18676 0.51022,-2.26768 1.34375,-3.125 l -0.875,-1.3125 C 283.95229,859.03012 283,860.60961 283,862.375 c 0,3.31371 3.35786,6 7.5,6 4.14214,0 7.5,-2.68629 7.5,-6 0,-1.98212 -1.21045,-3.71998 -3.0625,-4.8125 z"
+         id="path4378"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-179.88103,190.48725)"
+       style="display:inline"
+       id="g11442">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7330);enable-background:accumulate"
+         d="m 223.8125,745.28125 c -0.46695,0.0551 -0.823,0.4979 -0.8125,1.09375 l 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 l 3.59375,0 2.6875,2.6875 c 0.29466,0.29526 0.78339,0.37451 1.15626,0.1875 l 1,-0.5 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l 0,-3.59375 2.71875,-2.71875 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11.00001,-11.5 c -0.3075,-0.3075 -0.62608,-0.40806 -0.90625,-0.375 z"
+         id="path7464-1"
+         inkscape:connector-curvature="0" />
+      <g
+         id="g11419"
+         transform="translate(59.790918,-17.771933)">
+        <path
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+           d="m 163.20931,763.14731 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 0,0 3.88258,-1.25944 3.72633,-1.21534 l 2.55492,3.90284 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1.00846,-0.47958 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l -0.87488,-4.65633 3.58517,-1.67659 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.81999,-0.81999 -1.73555,-0.23461 -1.71875,0.71875 z"
+           id="path11421"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccccccc" />
+        <path
+           style="fill:#ffffff;fill-opacity:1;stroke:none"
+           d="m 164.20931,779.13449 0,-16 11,11.5 -3.86642,1.95784 0.9122,5.09495 -1.04578,0.44721 -2.86742,-4.21534 z"
+           id="path11423"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccccccc" />
+      </g>
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7358);enable-background:accumulate"
+         d="m 240.50001,758.375 c -3.58985,0 -6.5,2.91015 -6.5,6.5 0,3.58985 2.91015,6.5 6.5,6.5 3.58985,0 6.5,-2.91015 6.5,-6.5 0,-3.58985 -2.91015,-6.5 -6.5,-6.5 z"
+         id="path7458-4"
+         inkscape:connector-curvature="0" />
+      <circle
+         r="10.5"
+         cy="487.86218"
+         cx="394.5"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         id="path5519-7-2-28"
+         transform="matrix(0.61904741,0,0,0.61904741,-3.71421,461.85236)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#11d116;fill-opacity:1;stroke:none"
+         d="m 239.93751,758.375 c -2.77341,0.28165 -4.9375,2.65228 -4.9375,5.5 0,3.03757 2.46243,5.5 5.5,5.5 3.03757,0 5.5,-2.46243 5.5,-5.5 0,-3.03757 -2.46243,-5.5 -5.5,-5.5 -0.18985,0 -0.37761,-0.0188 -0.5625,0 z"
+         id="path4169-06-3"
+         sodipodi:nodetypes="cssssc" />
+      <path
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         d="m 240,760.375 0,3 -3,0 0,1 3,0 0,3 1,0 0,-3 3,0 0,-1 -3,0 0,-3 -1,0 z"
+         id="rect5428-0"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-197.88103,190.48725)"
+       style="display:inline"
+       id="g11452">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7382);enable-background:accumulate"
+         d="m 273.8125,745.28125 c -0.46695,0.0551 -0.823,0.4979 -0.8125,1.09375 l 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 l 3.59375,0 2.6875,2.6875 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1,-0.5 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l 0,-3.59375 2.71875,-2.71875 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.3075,-0.3075 -0.62608,-0.40806 -0.90625,-0.375 z"
+         id="path7462"
+         inkscape:connector-curvature="0" />
+      <g
+         transform="translate(109.79092,-17.771933)"
+         id="g11425">
+        <path
+           sodipodi:nodetypes="ccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path11427"
+           d="m 163.20931,763.14731 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 0,0 3.88258,-1.25944 3.72633,-1.21534 l 2.55492,3.90284 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1.00846,-0.47958 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l -0.87488,-4.65633 3.58517,-1.67659 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.81999,-0.81999 -1.73555,-0.23461 -1.71875,0.71875 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           inkscape:connector-curvature="0"
+           id="path11429"
+           d="m 164.20931,779.13449 0,-16 11,11.5 -3.86642,1.95784 0.9122,5.09495 -1.04578,0.44721 -2.86742,-4.21534 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7410);enable-background:accumulate"
+         d="m 290.5,758.375 c -3.58985,0 -6.5,2.91015 -6.5,6.5 0,3.58985 2.91015,6.5 6.5,6.5 3.58985,0 6.5,-2.91015 6.5,-6.5 0,-3.58985 -2.91015,-6.5 -6.5,-6.5 z"
+         id="path7456"
+         inkscape:connector-curvature="0" />
+      <circle
+         r="10.5"
+         cy="487.86218"
+         cx="394.5"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         id="path5519-7-2-3"
+         transform="matrix(0.61904741,0,0,0.61904741,46.28579,461.85236)" />
+      <path
+         style="fill:#ed1515;fill-opacity:1;stroke:none"
+         d="m 287.26495,759.39255 c -2.26102,1.63062 -2.94986,4.76569 -1.526,7.23189 1.51879,2.63062 4.88253,3.53192 7.51314,2.01314 2.6306,-1.51878 3.53192,-4.88252 2.01314,-7.51314 -1.51879,-2.63062 -4.88252,-3.53193 -7.51314,-2.01314 -0.16441,0.0949 -0.33642,0.17252 -0.48714,0.28125 z m 1.48714,1.4508 c 1.37589,-0.79437 3.05047,-0.54798 4.14577,0.49319 l -5.79154,3.34375 c -0.35403,-1.46915 0.26987,-3.04256 1.64577,-3.83694 z m -0.64577,5.56899 5.79154,-3.34375 c 0.35403,1.46916 -0.26987,3.04257 -1.64577,3.83694 -1.37588,0.79438 -3.05047,0.54798 -4.14577,-0.49319 z"
+         id="path5205"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       transform="translate(-163.88103,190.48725)"
+       style="display:inline"
+       id="g11431">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7274);enable-background:accumulate"
+         d="m 173.8125,745.28125 c -0.46695,0.0551 -0.823,0.4979 -0.8125,1.09375 l 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 l 3.59375,0 2.6875,2.6875 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1,-0.5 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l 0,-3.59375 2.71875,-2.71875 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.3075,-0.3075 -0.62608,-0.40806 -0.90625,-0.375 z"
+         id="path7464"
+         inkscape:connector-curvature="0" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7302);enable-background:accumulate"
+         d="m 190.5,758.375 c -3.58985,0 -6.5,2.91015 -6.5,6.5 0,3.58985 2.91015,6.5 6.5,6.5 3.58985,0 6.5,-2.91015 6.5,-6.5 0,-3.58985 -2.91015,-6.5 -6.5,-6.5 z"
+         id="path7458"
+         inkscape:connector-curvature="0" />
+      <circle
+         r="10.5"
+         cy="487.86218"
+         cx="394.5"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         id="path5519-7-2"
+         transform="matrix(0.61904741,0,0,0.61904741,-53.71421,461.85236)" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#3daee9;fill-opacity:1;stroke:none"
+         d="m 189.9375,758.375 c -2.77341,0.28165 -4.9375,2.65228 -4.9375,5.5 0,3.03757 2.46243,5.5 5.5,5.5 3.03757,0 5.5,-2.46243 5.5,-5.5 0,-3.03757 -2.46243,-5.5 -5.5,-5.5 -0.18985,0 -0.37761,-0.0188 -0.5625,0 z"
+         id="path4169-06"
+         sodipodi:nodetypes="cssssc" />
+      <path
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         d="m 188.66923,761.71482 -0.46404,-1.14905 c 0.54265,-1.46675 4.10113,-1.83626 4.97185,-0.0442 0.86413,1.7785 -1.39212,3.0273 -1.72357,3.73441 -0.46327,0.98833 -0.22097,1.21534 -0.22097,1.21534 l -1.32583,0 c 0,0 -0.55652,-1.22766 1.48051,-3.11569 1.11307,-1.03165 -0.75261,-3.0621 -2.71795,-0.64081 z"
+         id="path5233"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccssccsc" />
+      <circle
+         r="0.93912619"
+         cy="446.38272"
+         cx="460.60272"
+         transform="translate(-270,321)"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         id="path5235" />
+      <g
+         transform="translate(9.7909178,-17.771933)"
+         id="g11307">
+        <path
+           sodipodi:nodetypes="ccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path2998-2-3-5-7-1-8-8-7-0-48"
+           d="m 163.20931,763.14731 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 0,0 3.88258,-1.25944 3.72633,-1.21534 l 2.55492,3.90284 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1.00846,-0.47958 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l -0.87488,-4.65633 3.58517,-1.67659 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.81999,-0.81999 -1.73555,-0.23461 -1.71875,0.71875 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           inkscape:connector-curvature="0"
+           id="path2998-2-3-5-7-12"
+           d="m 164.20931,779.13449 0,-16 11,11.5 -3.86642,1.95784 0.9122,5.09495 -1.04578,0.44721 -2.86742,-4.21534 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <g
+       transform="translate(-179.88103,178.48725)"
+       style="display:inline"
+       id="g12534">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7618);enable-background:accumulate"
+         d="m 223.8125,795.28125 c -0.46695,0.0551 -0.823,0.4979 -0.8125,1.09375 l 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 l 3.59375,0 2.6875,2.6875 c 0.29466,0.29526 0.78339,0.37451 1.15626,0.1875 l 1,-0.5 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l 0,-3.59375 2.71875,-2.71875 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11.00001,-11.5 c -0.3075,-0.3075 -0.62608,-0.40806 -0.90625,-0.375 z"
+         id="path7464-8"
+         inkscape:connector-curvature="0" />
+      <circle
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         id="path5519-7-2-2"
+         cx="240.5"
+         cy="813.86218"
+         r="6.4999976" />
+      <path
+         inkscape:connector-curvature="0"
+         style="fill:#18c087;fill-opacity:1;stroke:none"
+         d="m 239.93751,808.375 c -2.77341,0.28165 -4.9375,2.65228 -4.9375,5.5 0,3.03757 2.46243,5.5 5.5,5.5 3.03757,0 5.5,-2.46243 5.5,-5.5 0,-3.03757 -2.46243,-5.5 -5.5,-5.5 -0.18985,0 -0.37761,-0.0188 -0.5625,0 z"
+         id="path4169-06-0"
+         sodipodi:nodetypes="cssssc" />
+      <path
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
+         d="m 238,818.36218 c 0,0 0,-1 0,-2 0,-1 1,-1 1,-1 l 2,0 0,2.5 4.5,-4 -4.5,-4 0,2.5 c 0,0 0,0 -2,0 -2,0 -4,4 -1,6 z"
+         id="path6742"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csccccccsc" />
+      <g
+         transform="translate(59.790918,32.228067)"
+         id="g11425-5-6"
+         style="display:inline">
+        <path
+           sodipodi:nodetypes="ccccccccccccc"
+           inkscape:connector-curvature="0"
+           id="path11427-0-3"
+           d="m 163.20931,763.14731 0,16 c 5e-5,0.52358 0.47642,0.99995 1,1 0,0 3.88258,-1.25944 3.72633,-1.21534 l 2.55492,3.90284 c 0.29466,0.29526 0.78338,0.37451 1.15625,0.1875 l 1.00846,-0.47958 c 0.32794,-0.15944 0.55359,-0.51046 0.5625,-0.875 l -0.87488,-4.65633 3.58517,-1.67659 c 0.36548,-0.36968 0.36548,-1.03657 0,-1.40625 l -11,-11.5 c -0.81999,-0.81999 -1.73555,-0.23461 -1.71875,0.71875 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+        <path
+           sodipodi:nodetypes="cccccccc"
+           inkscape:connector-curvature="0"
+           id="path11429-9-8"
+           d="m 164.20931,779.13449 0,-16 11,11.5 -3.86642,1.95784 0.9122,5.09495 -1.04578,0.44721 -2.86742,-4.21534 z"
+           style="fill:#ffffff;fill-opacity:1;stroke:none" />
+      </g>
+    </g>
+    <g
+       transform="translate(-20.947983,218.3823)"
+       style="display:inline"
+       id="g12314">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;opacity:0.2;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;filter:url(#filter7818);enable-background:accumulate"
+         d="m 40.5,795.125 c -0.70833,0 -1.4025,0.34917 -1.84375,0.9375 C 38.215,796.65083 38,797.45833 38,798.375 l 0,7 c -0.5529,-0.4091 -1.20332,-1.0332 -1.6875,-1.25 -0.97844,-0.43811 -1.87243,-0.52407 -2.59375,-0.3125 -1.44264,0.42314 -1.90625,1.8125 -1.90625,1.8125 l -0.21875,0.71875 0.625,0.4375 c 1.37572,0.92883 2.77007,3.20724 4.09375,5.3125 0.66184,1.05263 1.31432,2.03972 2.0625,2.84375 0.74818,0.80403 1.67183,1.47611 2.8125,1.46875 l 8.8125,-0.0312 0.90625,-0.0312 0.0937,-0.875 1,-10 c 0.14841,-1.4342 -0.72136,-2.65591 -1.84375,-3.03125 -0.54165,-0.18114 -1.16322,-0.0882 -1.71875,0.15625 -0.36471,-0.55879 -0.84191,-0.98136 -1.4375,-1.125 -0.50726,-0.12234 -1.04732,-0.0144 -1.53125,0.1875 -0.34754,-0.49621 -0.80181,-0.85745 -1.34375,-1.03125 -0.34899,-0.11192 -0.74694,-0.0251 -1.125,0.0312 l 0,-2.28125 c 0,-0.91667 -0.215,-1.72417 -0.65625,-2.3125 -0.44125,-0.58833 -1.13542,-0.9375 -1.84375,-0.9375 z"
+         id="path7448"
+         inkscape:connector-curvature="0" />
+      <path
+         inkscape:connector-curvature="0"
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#1a1a1a;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         d="m 40.5,794.125 c -0.70833,0 -1.4025,0.34917 -1.84375,0.9375 C 38.215,795.65083 38,796.45833 38,797.375 l 0,7 c -0.5529,-0.4091 -1.20332,-1.0332 -1.6875,-1.25 -0.97844,-0.43811 -1.87243,-0.52407 -2.59375,-0.3125 -1.44264,0.42314 -1.90625,1.8125 -1.90625,1.8125 l -0.21875,0.71875 0.625,0.4375 c 1.37572,0.92883 2.77007,3.20724 4.09375,5.3125 0.66184,1.05263 1.31432,2.03972 2.0625,2.84375 0.74818,0.80403 1.67183,1.47611 2.8125,1.46875 l 8.8125,-0.0312 0.90625,-0.0312 0.0937,-0.875 1,-10 c 0.14841,-1.4342 -0.72136,-2.65591 -1.84375,-3.03125 -0.54165,-0.18114 -1.16322,-0.0882 -1.71875,0.15625 -0.36471,-0.55879 -0.84191,-0.98136 -1.4375,-1.125 -0.50726,-0.12234 -1.04732,-0.0144 -1.53125,0.1875 -0.34754,-0.49621 -0.80181,-0.85745 -1.34375,-1.03125 -0.34899,-0.11192 -0.74694,-0.0252 -1.125,0.0312 l 0,-2.28125 c 0,-0.91667 -0.215,-1.72417 -0.65625,-2.3125 -0.44125,-0.58833 -1.13542,-0.9375 -1.84375,-0.9375 z"
+         id="path4236-1-58-5-5" />
+      <path
+         style="fill:#ffffff;fill-opacity:1;stroke:none"
+         d="m 41.16634,814.41914 8.83366,-0.057 1,-10 c 0.20975,-2.02695 -2.30257,-2.87035 -3,-1 0.009,-2.24769 -2.30352,-2.52892 -3,-1 0.0872,-1.85704 -2.27228,-2.5758 -3,-1 l 0,-3.99996 c 0,-3 -3,-3 -3,0 l 0,9 c -5,-5 -6.22597,-1.40715 -6.22597,-1.40715 3.39771,2.294 5.47595,9.48293 8.39231,9.46411 z"
+         id="path4236-1-58-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scccccsscss" />
+    </g>
+  </g>
+</svg>

--- a/src/build.sh
+++ b/src/build.sh
@@ -5,6 +5,21 @@
 
 # generate pixmaps from svg source
 SRC=$PWD
+SVG="svg"
+
+if [ "$1" == "--light" ]; then
+	if [ ! -d "svg-light" ]; then
+    mkdir "svg-light"
+	fi
+	SVG="svg-light"
+	for file in svg/* ; do
+		if [[ $(basename $file .svg) =~ (not-allowed|wayland-cursor|zoom-in|zoom-out) ]] ; then
+			cat $file > svg-light/$(basename $file)
+			continue
+		fi
+		awk -f swap.awk $file > svg-light/$(basename $file)
+	done
+fi
 
 if [ ! -d "x1" ]; then
     mkdir "x1"
@@ -13,7 +28,7 @@ if [ ! -d "x2" ]; then
     mkdir "x2"
 fi
 
-cd svg/
+cd $SVG
 find . -name "*.svg" -type f -exec sh -c 'inkscape -z -e "../x1/${0%.svg}.png" -w 32 -h 32 $0' {} \;
 find . -name "*.svg" -type f -exec sh -c 'inkscape -z -e "../x2/${0%.svg}.png" -w 64 -w 64 $0' {} \;
 

--- a/src/svg/pencil.svg
+++ b/src/svg/pencil.svg
@@ -82,7 +82,7 @@
          id="path4801-6-4-9"
          inkscape:connector-curvature="0" />
       <path
-         style="fill:#000000;fill-opacity:1;stroke:none"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
          d="m 88.65625,861.56252 -12.59375,12.625 -1.0625,3.1875 3.1875,-1.0625 12.59375,-12.625 z m 0.0312,1.4375 0.6875,0.6875 -1.3125,1.3125 -0.6875,-0.6875 z"
          id="path4801-6-4"
          inkscape:connector-curvature="0"

--- a/src/svg/top_right_corner.svg
+++ b/src/svg/top_right_corner.svg
@@ -126,7 +126,7 @@
          inkscape:connector-curvature="0"
          id="rect5654-9-4-00-8"
          d="m 30.33793,1022.1513 0,1 0,10 -1,0 0,-10 -10,0 0,-1 10,0 z"
-         style="display:inline;fill:#000000;fill-opacity:1;stroke:none" />
+         style="display:inline;fill:#1a1a1a;fill-opacity:1;stroke:none" />
     </g>
   </g>
 </svg>

--- a/src/svg/up-arrow.svg
+++ b/src/svg/up-arrow.svg
@@ -81,7 +81,7 @@
          id="path4801-2"
          inkscape:connector-curvature="0" />
       <path
-         style="fill:#000000;fill-opacity:1;stroke:none"
+         style="fill:#1a1a1a;fill-opacity:1;stroke:none"
          d="m 140.5,895.375 -3,6 2.5,0.84375 0,11.15625 1,0 0,-11.15625 2.5,-0.84375 -3,-6 z"
          id="path4801"
          inkscape:connector-curvature="0" />

--- a/src/swap.awk
+++ b/src/swap.awk
@@ -1,0 +1,11 @@
+#!/usr/bin/awk -f
+
+{
+	while (match($0, /fill:#1a1a1a|fill:#ffffff/)) {
+		printf "%s", substr($0,1, RSTART-1);
+		$0 = substr($0, RSTART);
+		printf "%s", /^fill:#1a1a1a/ ? "fill:#ffffff" : "fill:#1a1a1a";
+		$0 = substr($0, 1+RLENGTH)
+	}
+	print
+}


### PR DESCRIPTION
Pull request for #2 
After swapping the fill and stroke colors I noticed that:
1) Some colors hadn't swapped.
2) Some *.svg didn't look quite good with their colors swapped.

So the first commit is the correction of the colors, from `#000000` to `#1a1a1a`
The second commit is the change to the build script and the swap script.
The conditional in the for loop excludes the .svg that didn't look quite good in the light version, check them out and let me know if there's anything else.
Also, it's missing the update in the README.md about the `--light` flag in the build script.