### PR TITLE
Added `base-devel` to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,14 @@ sudo dnf install la-capitaine-cursor-theme
 
 #### Arch Linux
 There is an [AUR PKGBUILD](https://aur.archlinux.org/packages/capitaine-cursors/)
-maintained by caiye:
+maintained by caiye.  
+For its installation, the `base-devel` group is needed. Install it with `pacman`:
+```bash
+sudo pacman -S base-devel
 ```
+
+Now install `captaine-cursors` for example with `yaourt`:
+```bash
 yaourt -S capitaine-cursors
 ```
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,9 @@ sudo dnf install la-capitaine-cursor-theme
 
 #### Arch Linux
 There is an [AUR PKGBUILD](https://aur.archlinux.org/packages/capitaine-cursors/)
-maintained by caiye.  
-For its installation, the `base-devel` group is needed. Install it with `pacman`:
+maintained by caiye:
 ```bash
-sudo pacman -S base-devel
-```
-
-Now install `captaine-cursors` for example with `yaourt`:
-```bash
-yaourt -S capitaine-cursors
+yaourt -Syu base-devel capitaine-cursors
 ```
 
 ### Windows


### PR DESCRIPTION
Fix for issue #17. Install `base-devel` before installing `captaine-cursors` using `yaourt`.